### PR TITLE
Add scala 2.11 profile

### DIFF
--- a/ets-elasticsearch-rest-connector-core/pom.xml
+++ b/ets-elasticsearch-rest-connector-core/pom.xml
@@ -9,6 +9,19 @@
         <relativePath />
     </parent>
 
+    <!-- For galeria kaufhof internal purposes only, this profile will be removed in future!
+    This will not work for releases! The idea is to call mvn -P scala-2.11 package and copy the pure target/<lib>.jar
+    to the project using deprecated scala 2.11-->
+    <profiles>
+        <profile>
+            <id>scala-2.11</id>
+            <properties>
+                <ets.scala.version>2.11.12</ets.scala.version>
+                <ets.scala.compat.version>2.11</ets.scala.compat.version>
+            </properties>
+        </profile>
+    </profiles>
+
     <artifactId>ets-elasticsearch-rest-connector-core</artifactId>
     <version>0.1.0-SNAPSHOT</version>
 


### PR DESCRIPTION
This is only a profile for legacy projects and there is no guarantee
that everything will work properly when compiling with this profile - it
just configures all scala versions down to 2.11. It is only there to be
able to build a scala 2.11 variant of the lib on the local machine - not
for any automated publishing / pipeline workflow.
Call it with mvn -P scala-2.11 package and the corresponding jar in
target/ will be compiled against 2.11