### PR TITLE
implement inserting of one document besides the bulk-operation.

### DIFF
--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/ElasticInsertDocumentResult.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/ElasticInsertDocumentResult.scala
@@ -1,0 +1,34 @@
+package de.kaufhof.ets.elasticsearchrestconnector.core.client.model
+
+import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.indexing.ResultShardInfo
+import play.api.libs.json._
+
+case class ElasticInsertDocumentResult(
+                                        override val throwable: Option[Throwable] = None,
+                                        _shards: Option[ResultShardInfo] = None,
+                                        _index: String,
+                                        _type: String,
+                                        _id: String,
+                                        _version: Option[Long] = None,
+                                        _seq_no: Option[Long] = None,
+                                        _primary_term: Option[Long] = None,
+                                        result: Option[String] = None
+                                      ) extends ElasticResult
+
+
+object ElasticInsertDocumentResult {
+
+  def apply(jsResult: JsValue): ElasticInsertDocumentResult = {
+    ElasticInsertDocumentResult(
+      _index = (jsResult \ "_index").as[String],
+      _id = (jsResult \ "_id").as[String],
+      _type = (jsResult \ "_type").as[String],
+      _shards = (jsResult \ "_shards").asOpt[ResultShardInfo],
+      throwable = None,
+      _version = (jsResult \ "_version").asOpt[Long],
+      _seq_no = (jsResult \ "_seq_no").asOpt[Long],
+      result = (jsResult \ "result").asOpt[String],
+      _primary_term = (jsResult \ "_primary_term").asOpt[Long]
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/test/scala/de/kaufhof/ets/elasticsearchrestconnector/core/connector/ElasticsearchClientUriTest.scala
+++ b/ets-elasticsearch-rest-connector-core/src/test/scala/de/kaufhof/ets/elasticsearchrestconnector/core/connector/ElasticsearchClientUriTest.scala
@@ -1,0 +1,17 @@
+package de.kaufhof.ets.elasticsearchrestconnector.core.connector
+
+import org.apache.http.HttpHost
+import org.scalatest.{Matchers, WordSpec}
+
+class ElasticsearchClientUriTest extends WordSpec with Matchers {
+
+  "ElasticsearchClientUri" should {
+
+    "parse a valid uri" in {
+      val result = ElasticsearchClientUri("elasticsearch://server-1.tld:1000,server-2.tld:1001,server-3.tld:1002")
+      result.hosts should contain allOf("server-1.tld" -> 1000, "server-2.tld" -> 1001, "server-3.tld" -> 1002)
+    }
+
+  }
+
+}


### PR DESCRIPTION
With indexDocument, you can insert or update exact one document.
The resultset is in case of an error a 
ElasticInsertDocumentResult where Some(throwable) is filled or 
in case of success, the Resultset contains informations about the written document (e.g. created or updated, version etc.).
For later use, it will fine to implement the rest of the functionality as described here:
https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html
e,g,
- Routing
- Automatic Id
- Operation type
- ...
 