### PR TITLE
Internal Rework of Filter / Query - Calculation

### DIFF
--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/BoolFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/BoolFilter.scala
@@ -1,34 +1,34 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
-import play.api.libs.json.{JsArray, JsObject, JsValue, Writes}
+import play.api.libs.json._
 
 case class BoolFilter(
-                     should: List[FilterExpression] = List.empty[FilterExpression],
-                     must: List[FilterExpression] = List.empty[FilterExpression],
-                     mustNot: List[FilterExpression] = List.empty[FilterExpression]
-                     ) extends FilterExpression
-
-
-object BoolFilter {
-
-  implicit val writes: Writes[BoolFilter] = new Writes[BoolFilter] {
-    override def writes(o: BoolFilter): JsValue = {
-      apply(o)
+                       should: List[FilterExpression] = List.empty[FilterExpression],
+                       must: List[FilterExpression] = List.empty[FilterExpression],
+                       mustNot: List[FilterExpression] = List.empty[FilterExpression]
+                     ) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    if (isEmpty) {
+      Json.obj()
+    } else {
+      Json.obj(
+        "bool" -> JsObject(
+          (
+            generateEntries("must", must) ++
+              generateEntries("should", should) ++
+              generateEntries("must_not", mustNot)
+            ) toMap
+        )
+      )
     }
   }
 
-  def apply(q: BoolFilter): JsObject = {
-    JsObject(
-      (
-        generateEntries("must", q.must) ++
-        generateEntries("should", q.should) ++
-        generateEntries("must_not", q.mustNot)
-      ) toMap
-    )
+  private def isEmpty: Boolean = {
+    must.isEmpty && should.isEmpty && mustNot.isEmpty
   }
 
   private def generateEntries(elementName: String, elements: List[FilterExpression]): Option[(String, JsArray)] = {
-    if(elements.nonEmpty) {
+    if (elements.nonEmpty) {
       Some(elementName -> JsArray(elements.map(FilterExpression.writes.writes)))
     } else {
       None

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/ExistsFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/ExistsFilter.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
-case class ExistsFilter(field: String) extends FilterExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class ExistsFilter(field: String) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "exists" -> Json.obj(
+        "field" -> field
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/FilterExpression.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/FilterExpression.scala
@@ -3,73 +3,13 @@ package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 import play.api.libs.json._
 
 trait FilterExpression {
-
+  def toJsonObject: JsObject
 }
 
 object FilterExpression {
   implicit val writes: Writes[FilterExpression] = new Writes[FilterExpression] {
     override def writes(o: FilterExpression): JsValue = {
-      o match {
-        case t: TermFilter =>
-          Json.obj(
-            "term" -> Json.obj(
-              t.field -> t.value
-            )
-          )
-        case t: TermsFilter =>
-          Json.obj(
-            "terms" -> Json.obj(
-              t.field -> t.values
-            )
-          )
-        case r: RangeFilter =>
-          Json.obj(
-            "range" -> Json.obj(
-              r.fieldName -> JsObject(
-                Seq(
-                  r.gt.map {
-                    d => "gt" -> JsNumber(d)
-                  },
-                  r.gte.map {
-                    d => "gte" -> JsNumber(d)
-                  },
-                  r.lt.map {
-                    d => "lt" -> JsNumber(d)
-                  },
-                  r.lte.map {
-                    d => "lte" -> JsNumber(d)
-                  }).flatten
-              )
-            )
-          )
-        case e: ExistsFilter =>
-          Json.obj(
-            "exists" -> Json.obj(
-              "field" -> e.field
-            )
-          )
-        case m: MatchAllFilter =>
-          Json.obj(
-            "match_all" -> Json.obj()
-          )
-        case q: QueryFilter =>
-          Json.obj(
-            "query" -> q.query
-          )
-        case b: BoolFilter =>
-          if (getSizes(b) == 0) {
-            Json.obj()
-          } else {
-            Json.obj(
-              "bool" -> BoolFilter(b)
-            )
-          }
-      }
+      o.toJsonObject
     }
-  }
-
-
-  private def getSizes(b: BoolFilter): Int = {
-    b.must.size + b.should.size + b.mustNot.size
   }
 }

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MatchAllFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MatchAllFilter.scala
@@ -1,3 +1,11 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
-case class MatchAllFilter() extends FilterExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class MatchAllFilter() extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "match_all" -> Json.obj()
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MatchFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MatchFilter.scala
@@ -1,0 +1,13 @@
+package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
+
+import play.api.libs.json.{JsObject, JsString, Json}
+
+case class MatchFilter(fieldName: String, value: String) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "match" -> Json.obj(
+        fieldName -> JsString(value)
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MissingFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/MissingFilter.scala
@@ -1,3 +1,0 @@
-package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
-
-//case class MissingFilter(field: String) extends FilterExpression

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/QueryFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/QueryFilter.scala
@@ -1,5 +1,12 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryExpression
+import play.api.libs.json.{JsObject, Json}
 
-case class QueryFilter(query: QueryExpression) extends FilterExpression
+case class QueryFilter(query: QueryExpression) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "query" -> query
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/RangeFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/RangeFilter.scala
@@ -1,3 +1,26 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
+import play.api.libs.json.{JsNumber, JsObject, Json}
 
-case class RangeFilter(gt: Option[Double] = None, gte: Option[Double] = None, lt: Option[Double] = None, lte: Option[Double] = None, fieldName: String) extends FilterExpression
+case class RangeFilter(gt: Option[Double] = None, gte: Option[Double] = None, lt: Option[Double] = None, lte: Option[Double] = None, fieldName: String) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+              Json.obj(
+                "range" -> Json.obj(
+                  fieldName -> JsObject(
+                    Seq(
+                      gt.map {
+                        d => "gt" -> JsNumber(d)
+                      },
+                      gte.map {
+                        d => "gte" -> JsNumber(d)
+                      },
+                      lt.map {
+                        d => "lt" -> JsNumber(d)
+                      },
+                      lte.map {
+                        d => "lte" -> JsNumber(d)
+                      }).flatten
+                  )
+                )
+              )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/TermFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/TermFilter.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
-case class TermFilter(field: String, value: String) extends FilterExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class TermFilter(field: String, value: String) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "term" -> Json.obj(
+        field -> value
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/TermsFilter.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/filters/TermsFilter.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.filters
 
-case class TermsFilter(field: String, values: List[String]) extends FilterExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class TermsFilter(field: String, values: List[String]) extends FilterExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "terms" -> Json.obj(
+        field -> values
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/BoolQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/BoolQuery.scala
@@ -1,27 +1,22 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
-import play.api.libs.json.{JsArray, JsObject, JsValue, Writes}
+import play.api.libs.json._
 
 
 case class BoolQuery(
                       should: List[QueryExpression] = Nil,
                       must: List[QueryExpression] = Nil,
                       mustNot: List[QueryExpression] = Nil
-                    ) extends QueryExpression
-
-object BoolQuery {
-
-  implicit val writes: Writes[BoolQuery] = new Writes[BoolQuery] {
-    override def writes(o: BoolQuery): JsValue = {
-      apply(o)
-    }
-  }
-
-  def apply(q: BoolQuery): JsObject = {
-    JsObject(
-      generateEntries("must", q.must) ++
-        generateEntries("should", q.should) ++
-        generateEntries("must_not", q.mustNot) toMap
+                    ) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    //BoolQuery(this)
+    Json.obj(
+      "bool" ->
+        JsObject(
+          generateEntries("must", must) ++
+            generateEntries("should", should) ++
+            generateEntries("must_not", mustNot) toMap
+        )
     )
   }
 
@@ -32,5 +27,30 @@ object BoolQuery {
       None
     }
   }
-
 }
+
+//object BoolQuery {
+//
+//  implicit val writes: Writes[BoolQuery] = new Writes[BoolQuery] {
+//    override def writes(o: BoolQuery): JsValue = {
+//      apply(o)
+//    }
+//  }
+//
+//  def apply(q: BoolQuery): JsObject = {
+//    JsObject(
+//      generateEntries("must", q.must) ++
+//        generateEntries("should", q.should) ++
+//        generateEntries("must_not", q.mustNot) toMap
+//    )
+//  }
+//
+//  private def generateEntries(elementName: String, elements: List[QueryExpression]): Option[(String, JsArray)] = {
+//    if (elements.nonEmpty) {
+//      Some(elementName -> JsArray(elements.map(QueryExpression.writes.writes)))
+//    } else {
+//      None
+//    }
+//  }
+//
+//}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/ExistsQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/ExistsQuery.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
-case class ExistsQuery(field: String) extends QueryExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class ExistsQuery(field: String) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "exists" -> Json.obj(
+        "field" -> field
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MatchAllQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MatchAllQuery.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
-case class MatchAllQuery(boost: Int = 1) extends QueryExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class MatchAllQuery(boost: Int = 1) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "match_all" -> Json.obj(
+        "boost" -> boost
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MatchQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MatchQuery.scala
@@ -2,11 +2,11 @@ package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
 import play.api.libs.json.{JsObject, Json}
 
-case class TermQuery(field: String, value: String, boost: Double = 1.0) extends QueryExpression {
+case class MatchQuery(fieldName: String, value: String) extends QueryExpression {
   override def toJsonObject: JsObject = {
     Json.obj(
-      "term" -> Json.obj(
-        field -> value
+      "match" -> Json.obj(
+        fieldName -> value
       )
     )
   }

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MultiMatchQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/MultiMatchQuery.scala
@@ -1,9 +1,20 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryOperator.QueryOperator
+import play.api.libs.json.{JsObject, Json}
 
 case class MultiMatchQuery(
                             fields: List[String],
                             query: String,
                             operator: QueryOperator = QueryOperator.Or
-                          ) extends QueryExpression
+                          ) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "multi_match" -> Json.obj(
+        "query" -> query,
+        "fields" -> fields,
+        "operator" -> operator
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/QueryExpression.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/QueryExpression.scala
@@ -2,88 +2,14 @@ package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
 import play.api.libs.json._
 
-trait QueryExpression{}
+trait QueryExpression{
+  def toJsonObject: JsObject
+}
 
 object QueryExpression{
   implicit val writes: Writes[QueryExpression] = new Writes[QueryExpression] {
     override def writes(o: QueryExpression): JsValue = {
-      o match {
-        case t: TermQuery =>
-          Json.obj(
-            "term" -> Json.obj(
-              t.field -> t.value
-            )
-          )
-        case t: TermsQuery =>
-          Json.obj(
-            "terms" -> Json.obj(
-              t.field -> t.values
-            )
-          )
-        case r: RangeQuery =>
-          Json.obj(
-            "range" -> Json.obj(
-              r.fieldName -> JsObject(
-                Seq(
-                  Some("boost" -> JsNumber(r.boost)),
-                  r.gt.map {
-                    d => "gt" -> JsNumber(d)
-                  },
-                  r.gte.map {
-                    d => "gte" -> JsNumber(d)
-                  },
-                  r.lt.map {
-                    d => "lt" -> JsNumber(d)
-                  },
-                  r.lte.map {
-                    d => "lte" -> JsNumber(d)
-                  }).flatten
-              )
-            )
-          )
-        case m: MatchAllQuery =>
-          Json.obj(
-            "match_all" -> Json.obj(
-              "boost" -> m.boost
-            )
-          )
-        case m: MultiMatchQuery =>
-          Json.obj(
-            "multi_match" -> Json.obj(
-              "query" -> m.query,
-              "fields" -> m.fields,
-              "operator" -> m.operator
-            )
-          )
-        case w: WildCardQuery =>
-          Json.obj(
-            "wildcard" -> Json.obj(
-              w.field -> Json.obj(
-                "value" -> w.value,
-                "boost" -> w.boost
-              )
-            )
-          )
-        case q: QueryStringQuery =>
-          Json.obj(
-            "query_string" -> Json.obj(
-              "fields" -> q.fields,
-              "query" -> q.query,
-              "boost" -> q.boost,
-              "default_operator" -> q.defaultOperator
-            )
-          )
-        case b: BoolQuery =>
-          Json.obj(
-            "bool" -> BoolQuery(b)
-          )
-        case e: ExistsQuery =>
-          Json.obj(
-            "exists" -> Json.obj(
-              "field" -> e.field
-            )
-          )
-      }
+      o.toJsonObject
     }
   }
 }

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/QueryStringQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/QueryStringQuery.scala
@@ -1,5 +1,17 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryOperator.QueryOperator
+import play.api.libs.json.{JsObject, Json}
 
-case class QueryStringQuery(fields: List[String], query: String, boost: Double = 1.0, defaultOperator: QueryOperator = QueryOperator.Or) extends QueryExpression
+case class QueryStringQuery(fields: List[String], query: String, boost: Double = 1.0, defaultOperator: QueryOperator = QueryOperator.Or) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "query_string" -> Json.obj(
+        "fields" -> fields,
+        "query" -> query,
+        "boost" -> boost,
+        "default_operator" -> defaultOperator
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/RangeQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/RangeQuery.scala
@@ -1,9 +1,34 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
+import play.api.libs.json.{JsNumber, JsObject, Json}
+
 case class RangeQuery(
                        gt: Option[Double] = None,
                        gte: Option[Double] = None,
                        lt: Option[Double] = None,
                        lte: Option[Double] = None,
                        fieldName: String, boost: Double = 1.0
-                     ) extends QueryExpression
+                     ) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "range" -> Json.obj(
+        fieldName -> JsObject(
+          Seq(
+            Some("boost" -> JsNumber(boost)),
+            gt.map {
+              d => "gt" -> JsNumber(d)
+            },
+            gte.map {
+              d => "gte" -> JsNumber(d)
+            },
+            lt.map {
+              d => "lt" -> JsNumber(d)
+            },
+            lte.map {
+              d => "lte" -> JsNumber(d)
+            }).flatten
+        )
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/TermsQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/TermsQuery.scala
@@ -1,3 +1,13 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
-case class TermsQuery(field: String, values: List[String], minimumShouldMatch: Int = 1) extends QueryExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class TermsQuery(field: String, values: List[String], minimumShouldMatch: Int = 1) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "terms" -> Json.obj(
+        field -> values
+      )
+    )
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/WildCardQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/WildCardQuery.scala
@@ -1,3 +1,16 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries
 
-case class WildCardQuery(field: String, value: String, boost: Double = 1) extends QueryExpression
+import play.api.libs.json.{JsObject, Json}
+
+case class WildCardQuery(field: String, value: String, boost: Double = 1) extends QueryExpression {
+  override def toJsonObject: JsObject = {
+    Json.obj(
+      "wildcard" -> Json.obj(
+        field -> Json.obj(
+          "value" -> value,
+          "boost" -> boost
+        )
+      )
+    )
+  }
+}


### PR DESCRIPTION
Before, the appropriate trait for filters, queries calculates each filter- or query-type.
Now, each filter- or query-type contains his own logic for the calculation of the expression in json.
It's a more convinient way, also for testing.