### PR TITLE
Improvements

### DIFF
--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/percolate/PercolateQueryDocument.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/percolate/PercolateQueryDocument.scala
@@ -1,6 +1,7 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.percolate
 
-import play.api.libs.json.{JsValue, Json}
+import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.mapping.EnumMappingTypes
+import play.api.libs.json.{JsString, JsValue, Json}
 
 object PercolateQueryDocument {
   def apply(jsDocument: JsValue): JsValue = {
@@ -8,7 +9,8 @@ object PercolateQueryDocument {
       "query" -> Json.obj(
         "percolate" -> Json.obj(
           "field" -> "query",
-          "document" -> jsDocument
+          "document" -> jsDocument,
+          "type" -> JsString(EnumMappingTypes.Percolator.toString)
         )
       )
     )

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/BoolQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queries/BoolQuery.scala
@@ -28,29 +28,3 @@ case class BoolQuery(
     }
   }
 }
-
-//object BoolQuery {
-//
-//  implicit val writes: Writes[BoolQuery] = new Writes[BoolQuery] {
-//    override def writes(o: BoolQuery): JsValue = {
-//      apply(o)
-//    }
-//  }
-//
-//  def apply(q: BoolQuery): JsObject = {
-//    JsObject(
-//      generateEntries("must", q.must) ++
-//        generateEntries("should", q.should) ++
-//        generateEntries("must_not", q.mustNot) toMap
-//    )
-//  }
-//
-//  private def generateEntries(elementName: String, elements: List[QueryExpression]): Option[(String, JsArray)] = {
-//    if (elements.nonEmpty) {
-//      Some(elementName -> JsArray(elements.map(QueryExpression.writes.writes)))
-//    } else {
-//      None
-//    }
-//  }
-//
-//}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/HasChildQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/HasChildQuery.scala
@@ -2,9 +2,18 @@ package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queryTypes
 
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryType
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queryTypes.ScoreMode.ScoreMode
+import play.api.libs.json.{JsObject, Json}
 
 case class HasChildQuery(
                           childType: String,
                           query: QueryType,
                           scoreMode: ScoreMode = ScoreMode.None
-                        ) extends Query
+                        ) extends Query {
+  override def toJsonObject: JsObject = {
+    Json.obj("has_child" -> Json.obj(
+      "type" -> childType,
+      "query" -> query,
+      "score_mode" -> scoreMode
+    ))
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/Query.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/Query.scala
@@ -3,22 +3,13 @@ package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queryTypes
 import play.api.libs.json.{JsObject, JsValue, Json, Writes}
 
 trait Query{
-
+  def toJsonObject: JsObject
 }
 
 object Query{
   implicit val writes: Writes[Query] = new Writes[Query] {
     override def writes(o: Query): JsValue = {
-      o match {
-        case h: HasChildQuery =>
-          Json.obj("has_child" -> Json.obj(
-            "type" -> h.childType,
-            "query" -> h.query,
-            "score_mode" -> h.scoreMode
-          ))
-        case s: StandardQuery =>
-          Json.toJson(s.query).as[JsObject]
-      }
+      o.toJsonObject
     }
   }
 }

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/StandardQuery.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/queryTypes/StandardQuery.scala
@@ -1,5 +1,10 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queryTypes
 
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryType
+import play.api.libs.json.{JsObject, Json}
 
-case class StandardQuery(query: QueryType) extends Query
+case class StandardQuery(query: QueryType) extends Query {
+  override def toJsonObject: JsObject = {
+    Json.toJson(query).as[JsObject]
+  }
+}

--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/results/ElasticDeleteByQueryResult.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/results/ElasticDeleteByQueryResult.scala
@@ -13,7 +13,6 @@ object ElasticDeleteByQueryResultRetries {
 case class ElasticDeleteByQueryResult(
                                        override val throwable: Option[Throwable] = None,
                                        _index: String,
-                                       _type: String,
                                        took: Long = 0,
                                        timed_out: Option[Boolean] = None,
                                        deleted: Long = 0,
@@ -28,11 +27,10 @@ case class ElasticDeleteByQueryResult(
                                      ) extends ElasticResult
 
 object ElasticDeleteByQueryResult{
-  def apply(jsResult: JsValue, index: String, _type: String): ElasticDeleteByQueryResult = {
+  def apply(jsResult: JsValue, index: String): ElasticDeleteByQueryResult = {
     ElasticDeleteByQueryResult(
       throwable = None,
       _index = index,
-      _type = _type,
       took = (jsResult \ "took").asOpt[Long].getOrElse(9),
       timed_out = (jsResult \ "timed_out").asOpt[Boolean],
       deleted = (jsResult \ "deleted").as[Long],


### PR DESCRIPTION
- some improvements in object to json conversion
- add type to PercolateQueryDocument
- remove documenttype as not needed in es 6.x because of there is only one
  documenttype allowed per index