### PR TITLE
every document in an index become a special 'type'-field.

### DIFF
--- a/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/percolate/PercolateQueryObject.scala
+++ b/ets-elasticsearch-rest-connector-core/src/main/scala/de/kaufhof/ets/elasticsearchrestconnector/core/client/model/percolate/PercolateQueryObject.scala
@@ -1,15 +1,18 @@
 package de.kaufhof.ets.elasticsearchrestconnector.core.client.model.percolate
 
+import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.mapping.{EnumMappingTypes, TypeMappingProperty}
 import de.kaufhof.ets.elasticsearchrestconnector.core.client.model.queries.QueryListBool
-import play.api.libs.json.{JsObject, Json}
+import play.api.libs.json.{JsObject, JsString, Json}
 
 object PercolateQueryObject {
 
   def apply(o: QueryListBool): JsObject = {
+
     Json.obj(
       "query" -> Json.obj(
         "bool" -> QueryListBool.writes.writes(o)
-      )
+      ),
+      "type" -> EnumMappingTypes.Percolator.toString
     )
   }
 


### PR DESCRIPTION
look here for an explanation:
https://www.elastic.co/guide/en/elasticsearch/reference/6.x/removal-of-types.html#_alternatives_to_mapping_types